### PR TITLE
fixes problem minute='0'

### DIFF
--- a/angularjs-datetime-picker.js
+++ b/angularjs-datetime-picker.js
@@ -232,7 +232,11 @@
           var month = scope.month ? (scope.month-1) : today.getMonth();
           var day = scope.day || today.getDate();
           var hour = scope.hour || today.getHours();
-          var minute = scope.minute || today.getMinutes();
+          if(scope.minute == 0){
+            var minute = 0
+          } else{
+            var minute = scope.minute || today.getMinutes();
+          }
           scope.selectedDate = new Date(year, month, day, hour, minute, 0);
         }
         scope.inputHour   = scope.selectedDate.getHours();


### PR DESCRIPTION
Hello,

This is my first pull request so bear with me :)

I noticed having something of the like doesn't work (minutes are still using the current time):
`<input datetime-picker ng-model="model" minute='0'/>`

I tried made some little changes to the source code, it seems to work for me. You might have something more elegant than this :)

PS: I didn't change the minified version, I am not sure if I am supposed to do it when doing a pull request.
