### PR TITLE
Fix missing comma in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "gulp-strip-debug": "^1.0.2",
     "gulp-uglify": "^1.2.0",
     "run-sequence": "^1.1.0"
-  }
+  },
   "homepage": "https://github.com/kineticsocial/angularjs-datetime-picker"
 }


### PR DESCRIPTION
This caused issues with package managers such as yarn/npm/etc as they could not read `package.json` to determine the transitive dependencies.